### PR TITLE
choicesテーブルのuser_id削除のための動作確認

### DIFF
--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -1,6 +1,7 @@
 class Choice < ApplicationRecord
   belongs_to :user
   belongs_to :question
+  self.ignored_columns = [:user_id]
 
   enum correct_answer: { incorrect: 0, correct: 1}
 


### PR DESCRIPTION
## 概要

choicesテーブルのuser_id削除のため、
- 本番環境で影響がないかを確認する。
- 本番環境で読み込まれるスキーマから除外しておく。