### PR TITLE
choicesテーブルからuser_idを削除

### DIFF
--- a/db/migrate/20220804095135_choices.rb
+++ b/db/migrate/20220804095135_choices.rb
@@ -1,0 +1,5 @@
+class Choices < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :choices, :user_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_07_063854) do
+ActiveRecord::Schema.define(version: 2022_08_04_095135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,10 +21,8 @@ ActiveRecord::Schema.define(version: 2022_07_07_063854) do
     t.integer "correct_answer", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.uuid "user_id", null: false
     t.uuid "question_id", null: false
     t.index ["question_id"], name: "index_choices_on_question_id"
-    t.index ["user_id"], name: "index_choices_on_user_id"
   end
 
   create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -58,7 +56,6 @@ ActiveRecord::Schema.define(version: 2022_07_07_063854) do
   end
 
   add_foreign_key "choices", "questions"
-  add_foreign_key "choices", "users"
   add_foreign_key "messages", "users"
   add_foreign_key "questions", "users"
 end


### PR DESCRIPTION
## 概要

choicesテーブルからuser_idを削除。

## 確認方法

1. カラムを削除したので `bundle exec rails db:migrate` を実行してください