### PR TITLE
Add: シェア設定機能の追加

### DIFF
--- a/app/controllers/quiz_tops_controller.rb
+++ b/app/controllers/quiz_tops_controller.rb
@@ -46,6 +46,6 @@ class QuizTopsController < ApplicationController
   end
 
   def quiz_top_params
-    params.require(:quiz_top).permit(:title, :explain, :photo, :photo_cache).merge(user_id: current_user.id)
+    params.require(:quiz_top).permit(:title, :explain, :photo, :photo_cache, :twitter_share).merge(user_id: current_user.id)
   end
 end

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -28,7 +28,7 @@
 }
 
 .common_container {
-  @apply container p-5 mx-auto;
+  @apply container max-w-max p-5 mx-auto;
 }
 
 .quiz-container {

--- a/app/models/quiz_top.rb
+++ b/app/models/quiz_top.rb
@@ -4,5 +4,5 @@ class QuizTop < ApplicationRecord
 
   validates :title, presence: true
   validates :explain, presence: true
-  validates :twitter_share, presence: true
+  validates :twitter_share, inclusion: {in: [true, false]}
 end

--- a/app/models/quiz_top.rb
+++ b/app/models/quiz_top.rb
@@ -4,4 +4,5 @@ class QuizTop < ApplicationRecord
 
   validates :title, presence: true
   validates :explain, presence: true
+  validates :twitter_share, presence: true
 end

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -21,10 +21,12 @@
       </div>
     </div>
     <div class="bg-base-100">
-      <div class="result-container title-font md: mb-0">
-        <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.share')) %></h4>
-        <%= render 'twitter_point', user: @user, score: @score %>
-      </div>
+      <% if @user.quiz_top.twitter_share %>
+        <div class="result-container title-font md: mb-0">
+          <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.share')) %></h4>
+          <%= render 'twitter_point', user: @user, score: @score %>
+        </div>
+      <% end %>
       <div class="result-container title-font md: mb-0">
         <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.once_more')) %></h4>
         <button class="text-orange-500 text-md font-bold"><%= link_to t('.try_again'), user_quiz_top_path(user_id: @user.id) %></button>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -20,10 +20,12 @@
     <% if @message %>
       <div class="after-sent-message">
         <div class="bg-base-100">
-          <div class="result-container title-font md: mb-0">
-            <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.share')) %></h4>
-            <%= render 'twitter_point', user: @user, score: @score %>
-          </div>
+          <% if @user.quiz_top.twitter_share %>
+            <div class="result-container title-font md: mb-0">
+              <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.share')) %></h4>
+              <%= render 'twitter_point', user: @user, score: @score %>
+            </div>
+          <% end %>
           <div class="result-container title-font md: mb-0">
             <h4 class="text-md mx-auto px-6 py-3 text-center"><%= simple_format(t('.once_more')) %></h4>
             <button class="text-orange-500 text-md font-bold"><%= link_to t('.try_again'), user_quiz_top_path(user_id: @user.id) %></button>

--- a/app/views/quiz_tops/_form.html.erb
+++ b/app/views/quiz_tops/_form.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div>
     <%= f.label :photo, class: 'block' %>
-    <%= f.file_field :photo, accept: 'image/*', id: 'action-button', class: 'input input-bordered w-full mb-3 px-4 py-3 rounded-full' %>
+    <%= f.file_field :photo, accept: 'image/*', id: 'action-button' %>
     <%= f.hidden_field :photo_cache %>
   </div>
   <div class='mt-3 mb-3'>
@@ -17,7 +17,20 @@
   </div>
   <div>
     <%= f.label :explain %>
-    <%= f.text_field :explain, class: 'input input-bordered w-full mb-3 px-4 py-3 rounded-full' %>
+    <%= f.text_area :explain, class: 'textarea w-full mb-3 px-4 py-3 rounded-full' %>
+  </div>
+  <div class='mt-3 mb-6'>
+    Twitterシェアボタン
+    <ul>
+      <li>
+        <%= f.radio_button :twitter_share, 'true', class: 'radio' %>
+        <%= f.label :twitter_true, '表示する', class: 'text-center' %>
+      </li>
+      <li>
+        <%= f.radio_button :twitter_share, 'false', class: 'radio' %>
+        <%= f.label :twitter_false, '表示しない', class: 'text-center' %>
+      </li>
+    </ul>
   </div>
   <%= f.submit class:'btn btn-accent mb-5' %>
 <% end %>

--- a/app/views/quiz_tops/show.html.erb
+++ b/app/views/quiz_tops/show.html.erb
@@ -1,19 +1,21 @@
 <% set_meta_tags title: t('.title') %>
-<div class="common-container">
+<div class="common_container">
   <div class="flex flex-col title-font font-medium items-center text-gray-600 mb-4 md: mb-0">
     <h1 class="text-2xl text-gray-600 mx-auto px-6 py-3 text-center"><%= t '.title' %></h1>
-    <div class="card w-96 rounded-xl shadow-xl max-w-md justify-center text-center">
+      <div class="self-end btn btn-outline btn-success">
+        <%= link_to edit_quiz_top_path(@quiz_top) do %>
+          <%= t('defaults.edit') %><%= icon 'fa', 'pen' %>
+        <% end %>
+      </div>
+    <p class="self-start font-bold">クイズ画面：</p>
+    <div class="card w-96 mb-3 py-6 rounded-xl shadow-md justify-center text-center">
       <h1 class="text-5xl font-app py-6"><%= @quiz_top.title %></h1>
       <div class='col-md-3 m-auto'>
         <%= image_tag @quiz_top.photo.url, class: 'img-fluid', size: '300x300' %>
       </div>
       <p class="px-24 py-6"><%= @quiz_top.explain %></p>
       <button class="btn btn-accent w-1/3 m-auto">スタート</button>
-      <div class="py-6">
-        <%= link_to edit_quiz_top_path(@quiz_top) do %>
-          <%= icon 'fa', 'pen' %>
-        <% end %>
-      </div>
     </div>
+    <p class="font-bold self-start">Twitterシェアボタン：<%= t("helpers.#{@quiz_top.twitter_share.to_s}") %></p>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,7 +4,7 @@ ja:
       user: "ユーザー"
       question: "質問"
       choice: "選択肢"
-      quiz_top: "クイズトップ"
+      quiz_top: "クイズトップ・シェア設定"
       message: "メッセージ"
     attributes:
       user:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -26,12 +26,12 @@ ja:
         title: "タイトル"
         photo: "画像"
         explain: "説明"
+        twitter_share: "Twitterシェア設定"
       message:
         name: "お名前"
         body: "メッセージ"
     errors:
       messages:
-
   enum:
     question:
       level:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -89,12 +89,10 @@ ja:
       welcome_message: 'ようこそ！'
       no_quiz: 'クイズを３問以上つくると<br/>スタートボタンが表示されます'
       button: 'スタート'
-    new:
-      title: 'クイズトップ作成'
     show:
       title: 'クイズ画面・シェア設定'
     edit:
-      title: 'クイズトップ編集'
+      title: 'クイズ画面・シェア設定編集'
   take_quizzes:
     index:
       title_1: 'Question 1'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -92,7 +92,7 @@ ja:
     new:
       title: 'クイズトップ作成'
     show:
-      title: 'クイズトップ詳細'
+      title: 'クイズ画面・シェア設定'
     edit:
       title: 'クイズトップ編集'
   take_quizzes:
@@ -142,3 +142,5 @@ ja:
       submit: '保存する'
       message:
         create: '送る'
+    "true": '表示する'
+    "false": '表示しない'

--- a/db/migrate/20221006090621_add_twitter_share_to_quiz_tops.rb
+++ b/db/migrate/20221006090621_add_twitter_share_to_quiz_tops.rb
@@ -1,0 +1,5 @@
+class AddTwitterShareToQuizTops < ActiveRecord::Migration[6.1]
+  def change
+    add_column :quiz_tops, :twitter_share, :boolean, default: false, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_15_042413) do
+ActiveRecord::Schema.define(version: 2022_10_06_090621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2022_09_15_042413) do
     t.uuid "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "twitter_share", default: false, null: false
     t.index ["user_id"], name: "index_quiz_tops_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

- Twitterシェアボタンの表示可否を設定できる機能を追加

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください

close #107