### PR TITLE
Fix: クイズスタート時のログイン要求をスキップするよう修正

### DIFF
--- a/app/controllers/take_quizzes_controller.rb
+++ b/app/controllers/take_quizzes_controller.rb
@@ -1,4 +1,6 @@
 class TakeQuizzesController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
+
   def index
     @user = User.find(params[:user_id])
     @quiz_1, @quiz_2, @quiz_3 = @user.questions.sample(3)


### PR DESCRIPTION
## 概要

- クイズスタートボタンを押した後、ログイン画面に遷移するバグを修正。

## 確認方法

ログイン不要で回答画面に遷移することを確認すること。